### PR TITLE
feat: responsiveness

### DIFF
--- a/src/components/MessageView.js
+++ b/src/components/MessageView.js
@@ -4,11 +4,12 @@ import { useState, useEffect } from 'react'
 import Message from './Message'
 import TextField from '@mui/material/TextField'
 import InputAdornment from '@mui/material/InputAdornment'
-
-import SendIcon from '@mui/icons-material/Send'
 import IconButton from '@mui/material/IconButton'
 
-function MessageView ({ socket, windowHeight, meeting, ...props }) {
+import SendIcon from '@mui/icons-material/Send'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+function MessageView ({ socket, windowHeight, meeting, closeDrawer, ...props }) {
   const [messages, setMessages] = useState([])
   const [input, setInput] = useState(null)
 
@@ -119,8 +120,25 @@ function MessageView ({ socket, windowHeight, meeting, ...props }) {
     })
   }
 
+  const drawerWidth = () => {
+    if (window.innerWidth > 569) return {width: "260px"};
+    else return {width: window.innerWidth.toString() + "px"};
+  }
+
+  const showReturnButton = () => {
+    if (window.innerWidth > 569) return null
+    return (
+      <IconButton className="max-drawer-return" onClick={() => {
+        closeDrawer()
+      }}>
+        <ArrowBackIcon />
+      </IconButton>
+    )
+  }
+
   return (
-    <div className='message-view'>
+    <div className='message-view' style={drawerWidth()}>
+      {showReturnButton()}
       <div
         id='messages' style={{
           width: '100%',

--- a/src/components/Stream.js
+++ b/src/components/Stream.js
@@ -6,18 +6,13 @@ function Stream ({ srcObj, cam, mic, ...props }) {
   const setSize = () => {
     // Self camera
     if (cam !== undefined || mic !== undefined) {
-      streamRef.current.style.width = '250px'
-      streamRef.current.style.height = '150px'
+      streamRef.current.className = 'self-stream'
       return
     }
 
-    let width, height
     const parent = streamRef.current.parentNode
-
-    if (parent.style.height >= parent.style.width) { height = '85%'; width = 'auto' } else { width = '85%'; height = 'auto' }
-
-    streamRef.current.style.width = width
-    streamRef.current.style.height = height
+    streamRef.current.style.width = parent.style.width
+    streamRef.current.style.height = parent.style.height
   }
 
   // We wrap the streamRef's operations into a useEffect

--- a/src/components/VideoGrid.js
+++ b/src/components/VideoGrid.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import Stream from './Stream'
 
-function VideoGrid ({ selfStream, socket, peer, micPerm, camPerm, showAlert, drawerWidth }) {
+function VideoGrid ({ selfStream, socket, peer, micPerm, camPerm, showAlert }) {
   const [streams, updateStreams] = useState([])
   const streamRef = useRef(streams)
   const height = window.innerHeight
@@ -21,7 +21,6 @@ function VideoGrid ({ selfStream, socket, peer, micPerm, camPerm, showAlert, dra
   // then removes any of his streams from state.
   const handleDisconnect = (msg, streams) => {
     const index = streams.findIndex(stream => stream.peerID === msg.PeerID)
-
     // If found
     if (index > -1) {
       // Deep copy the streams array
@@ -65,11 +64,7 @@ function VideoGrid ({ selfStream, socket, peer, micPerm, camPerm, showAlert, dra
   }, [])
 
   return (
-    <div
-      className='video-grid' style={{
-        width: `calc(100% - ${drawerWidth})`
-      }}
-    >
+    <div className='video-grid'>
       {
         streams.map(streamObj => {
           const remoteStream = streamObj.stream

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -12,7 +12,7 @@ html, body, #root, .home-page {
 
 #create-meeting {
     margin: 30px;
-    margin-top: 120px;
+    margin-top: 15vh;
     width: 400px;
     padding: 10px;
 }

--- a/src/css/video.css
+++ b/src/css/video.css
@@ -1,3 +1,7 @@
+* {
+    box-sizing: border-box;
+}
+
 html, body, #root, .video-page {
     padding: 0;
     margin: 0;
@@ -51,7 +55,6 @@ h4 {
 .nav-menu {
     position: fixed;
     top: auto;
-    width: 100%;
     bottom: 0;
     background-color: black;
 }
@@ -72,9 +75,7 @@ h4 {
 }
 
 .message-view {
-    width: 20vw;
     min-width: 150px;
-    max-width: 350px;
     background-color: #ecf0f1;
     height: 100%;
     display: grid;
@@ -105,8 +106,34 @@ h4 {
 }
 
 .video-grid {
-    display: grid;
     height: 100%;
-    grid-template-columns: 5fr 1fr;
-    grid-template-rows: 1fr;
+    width: 100%;
+}
+
+.self-stream {
+    width: 250px;
+    height: 150px;
+    position: fixed;
+    left: 0px;
+    bottom: 80px;
+}
+
+.max-drawer-return {
+    position: fixed !important;
+    top: 5px;
+    left: 5px;
+}
+
+@media screen and (max-height: 600px) {
+    .self-stream {
+        width: 200px;
+        height: 120px;
+    }
+}
+
+@media screen and (max-height: 500px) {
+    .self-stream {
+        width: 120px;
+        height: 80px;
+    }
 }


### PR DESCRIPTION
Features & changes:
- Chat drawer becomes full-screen when the screen width can't fit both the menu bar and chat drawer. 
- The video grid and its constituent streams resize themselves so that remote streams don't overflow.
- The client's self stream (i.e your personal webcam view) is now a fixed-position element.
- The client's self stream will resize itself to reduce overlap with the remote stream in smaller screens.
- Fixed a bug where the client would send null as their PeerID. 